### PR TITLE
try to get the Pkg.test subprocess to detect sixel compat

### DIFF
--- a/src/Sixel.jl
+++ b/src/Sixel.jl
@@ -38,16 +38,20 @@ include("frontend/fileio.jl")
 
 # Ref: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
 """
-    is_sixel_supported(tty=stdout)::Bool
+    is_sixel_supported()::Bool
 
-Check if given terminal `tty` supports sixel format.
+Check if the current terminal supports sixel format.
 
 !!! warning
     (Experiment) The return value is not fully tested on all terminals and all platforms.
 """
-function is_sixel_supported(tty::Base.TTY=stdout)
-    '4' in TerminalTools.query_terminal("\033[0c", tty)
+function is_sixel_supported()
+    return '4' in TerminalTools.query_terminal("\033[>c")
 end
+function is_sixel_supported(tty::TTY)
+    return '4' in TerminalTools.query_terminal("\033[>c", tty)
+end
+is_sixel_supported(ioc::IOContext) = is_sixel_supported(ioc.io)
 is_sixel_supported(io::IO) = false
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ using ImageQualityIndexes
 using LinearAlgebra
 using FileIO, TestImages
 
+@show stdin stdout stderr
+@show Sixel.TerminalTools.query_terminal("\033[>c")
 sixel_output = Sixel.is_sixel_supported()
 sixel_output || @info "Current terminal does not support sixel format sequence. Display tests to stdout will be marked as broken."
 function test_sixel_display(f)


### PR DESCRIPTION
Currently `is_sixel_supported()` returns false within Pkg.test within a terminal that otherwise returns true, which is a shame because that's one of the most useful places for Sixel to run.

I think it's something to do with stdin not being forwarded properly by Pkg.test.
@oxinabox I recall you reported an issue like that in the past, but I couldn't find it in Pkg.jl issues.

Note stdin isn't forwarded here https://github.com/JuliaLang/Pkg.jl/blob/12c3eaf1a896edfc21bb935500bf905d42067a8a/src/Operations.jl#L2437

So in Sixel tests via Pkg.test we get
```
stdin = IOStream(<fd 8>)
stdout = Base.TTY(RawFD(10) open, 0 bytes waiting)
stderr = Base.TTY(RawFD(13) open, 0 bytes waiting)
```