### PR TITLE
Fix querying device attributes on Windows

### DIFF
--- a/src/Sixel.jl
+++ b/src/Sixel.jl
@@ -46,7 +46,8 @@ Check if given terminal `tty` supports sixel format.
     (Experiment) The return value is not fully tested on all terminals and all platforms.
 """
 function is_sixel_supported(tty::Base.TTY=stdout)
-    '4' in TerminalTools.query_terminal("\033[0c", tty)
+    device_attributes = TerminalTools.query_terminal("\033[0c", tty)
+    "4" in split(chop(device_attributes), ';')
 end
 is_sixel_supported(io::IO) = false
 

--- a/src/terminaltools.jl
+++ b/src/terminaltools.jl
@@ -54,7 +54,15 @@ function query_terminal(msg, tty::TTY; timeout=1)
         timeout_call(timeout; pollint=timeout/100) do
             with_raw(term) do
                 write(tty, msg)
-                return transcode(String, readavailable(tty))
+                return @static if Sys.iswindows()
+                    response = ""
+                    while !endswith(response, 'c')
+                        response *= read(stdin, Char)
+                    end
+                    response
+                else
+                    transcode(String, readavailable(tty))
+                end
             end
         end
     catch e


### PR DESCRIPTION
Fixes #30
Should fix #15 as well, but I have not tested explicitly

This should fix the `is_sixel_supported` function on Windows. It seems that on Windows one must explicitly read the response of the device attributes query `\033[0c` from the `stdin` stream (see also https://github.com/microsoft/terminal/issues/1040#issuecomment-3001194047).

I have tested in Windows Terminal, which does support Sixel graphics, and with Julia started from plain command prompt (no Sixel support).

Note that the line at
https://github.com/JuliaIO/Sixel.jl/blob/0602d284947bae07c3acd64942366cdb6e325985/src/Sixel.jl#L49
was also not fully correct. For example, on the Windows command prompt the returned value looks like `\e[?61;1;6;7;21;22;23;24;28;32;42c`. Here the function accidentally returned `true` as well, because the `4` (for Sixel graphics support) got wrongly matched in the `42` at the end. This PR fixes that as well.