### PR TITLE
Do not silence unexpected exceptions

### DIFF
--- a/src/terminaltools.jl
+++ b/src/terminaltools.jl
@@ -67,6 +67,7 @@ function query_terminal(msg, tty::TTY; timeout=1)
         end
     catch e
         e isa TimeoutException && return ""
+        rethrow()
     end
 end
 function query_terminal(msg, regex, tty::TTY; kwargs...)


### PR DESCRIPTION
If an exception is thrown that is not of type `TimeoutException`, then `query_terminal` used to return a `Bool`.

See https://discourse.julialang.org/t/reference-tests-fail-locally-but-pass-on-github-actions/130271/